### PR TITLE
feat: add proper error_page support

### DIFF
--- a/docs/utils.md
+++ b/docs/utils.md
@@ -2,7 +2,7 @@
 
 ## `_utils.mkVhost`
 `attrset -> attrset`
-make virtual host with sensible defaults
+make a virtual host with sensible defaults
 
 pass in a set to override the defaults.
 
@@ -22,9 +22,16 @@ takes a set:
   port,
   protocol ? "http",
   location ? "/",
-  websockets ? false
+  websockets ? false,
+  extraConfig ? {}
 }
 ```
+
+It is recommended to override/add attributes with `extraConfig` to
+preserve defaults.
+
+Items in `extraConfig` are merged verbatim to the base attrset with defaults.
+They are overridden based on their order.
 
 ## `_utils.genSecrets`
 `namespace[str] -> files[list[str]] -> value[attrset] -> attrset`

--- a/systems/koumakan/services/attic.nix
+++ b/systems/koumakan/services/attic.nix
@@ -39,9 +39,9 @@ in {
     };
   };
 
-  services.nginx.virtualHosts."nonbunary.soopy.moe" =
-    _utils.mkSimpleProxy {port = 38191;}
-    // {
+  services.nginx.virtualHosts."nonbunary.soopy.moe" = _utils.mkSimpleProxy {
+    port = 38191;
+    extraConfig = {
       extraConfig = ''
         client_max_body_size 1G;
         proxy_read_timeout 3h;
@@ -49,4 +49,5 @@ in {
         proxy_send_timeout 3h;
       '';
     };
+  };
 }

--- a/systems/koumakan/services/static-sites/keine.nix
+++ b/systems/koumakan/services/static-sites/keine.nix
@@ -1,6 +1,6 @@
-{...}: {
-  services.nginx.virtualHosts."keine.soopy.moe" = {
-    useACMEHost = "global.c.soopy.moe";
+{_utils, ...}: {
+  services.nginx.virtualHosts."keine.soopy.moe" = _utils.mkVhost {
+    forceSSL = false;
     addSSL = true; # Don't force SSL on a mirror (implications TBD)
 
     root = "/srv/www/keine";


### PR DESCRIPTION
This PR changes the logic used in `_utils.mkVhost` to use `lib.mkMerge` instead of `//`.

This PR also changes the method to merge attrsets with a new attribute argument, `extraConfig`.

All changes are documented.